### PR TITLE
Fix dependencies version pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ requests==2.32.3
 requests-oauthlib==2.0.0
 python-dotenv==1.1.0
 reportlab==4.4.1
-plotly
-wordcloud
+plotly==5.21.0
+wordcloud==1.9.3


### PR DESCRIPTION
## Summary
- pin versions for `plotly` and `wordcloud` in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f9c0bc5b88332ba02ca406138345e