### PR TITLE
Add PDF viewer module

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from modules.auth import (
     init_session_state, logout
 )
 from modules.sheets_utils import load_movimientos_data
-from modules import dashboard, ingresos, egresos, subir, reportes, configuracion, edicion, login
+from modules import dashboard, ingresos, egresos, subir, reportes, configuracion, edicion, login, visor
 
 
 st.set_page_config(
@@ -22,7 +22,15 @@ else:
     st.sidebar.title(f"👋 Bienvenido, {st.session_state['name']}")
     st.sidebar.info(f"🔑 Usuario: {st.session_state['username']}")
     st.sidebar.divider()
-    menu_options = ["📊 Dashboard", "💰 Ingresos", "💸 Egresos", "📄 Subida de Extractos", "📈 Reportes", "📝 Edición Manual"]
+    menu_options = [
+        "📊 Dashboard",
+        "💰 Ingresos",
+        "💸 Egresos",
+        "📄 Subida de Extractos",
+        "📑 Visor de PDFs",
+        "📈 Reportes",
+        "📝 Edición Manual",
+    ]
     menu = st.sidebar.radio("Navegación", menu_options)
     st.sidebar.divider()
     if st.sidebar.button("🚪 Cerrar sesión"):
@@ -37,6 +45,8 @@ else:
         egresos.render(movimientos_df)
     elif menu == "📄 Subida de Extractos":
         subir.render(movimientos_df)
+    elif menu == "📑 Visor de PDFs":
+        visor.render(movimientos_df)
     elif menu == "📈 Reportes":
         reportes.render(movimientos_df, extractos_df)
     elif menu == "📝 Edición Manual":

--- a/modules/visor.py
+++ b/modules/visor.py
@@ -1,0 +1,36 @@
+import streamlit as st
+import tempfile
+from pathlib import Path
+import base64
+from modules.pdf_parser import extract_data_from_pdf
+
+
+def render(movimientos_df):
+    """Visualiza un archivo PDF y muestra los movimientos detectados."""
+    st.title("📑 Visor de PDFs")
+    st.caption("Carga un PDF para ver el archivo junto con los movimientos extraídos.")
+
+    uploaded_file = st.file_uploader("Selecciona un archivo PDF", type="pdf")
+    if not uploaded_file:
+        return
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_file:
+        tmp_file.write(uploaded_file.getbuffer())
+        tmp_path = tmp_file.name
+
+    df_mov, df_ext, banco, _ = extract_data_from_pdf(tmp_path, filename=uploaded_file.name)
+
+    with open(tmp_path, "rb") as f:
+        b64_pdf = base64.b64encode(f.read()).decode("utf-8")
+    pdf_display = f'<iframe src="data:application/pdf;base64,{b64_pdf}" width="700" height="1000" type="application/pdf"></iframe>'
+    st.markdown(pdf_display, unsafe_allow_html=True)
+
+    st.subheader("Movimientos Detectados")
+    st.dataframe(df_mov, use_container_width=True)
+
+    if not df_ext.empty:
+        st.subheader("Resumen de Extracto")
+        st.dataframe(df_ext, use_container_width=True)
+
+    Path(tmp_path).unlink()
+


### PR DESCRIPTION
## Summary
- add new `visor` module for viewing processed PDFs alongside extracted data
- integrate viewer into Streamlit sidebar menu

## Testing
- `python -m py_compile app.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686fa34fe6788332a71ad70c8e9e6f11